### PR TITLE
Refactor file upload interface into tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,49 +167,368 @@ def clean_and_prepare_data(_df_sessions, _df_users):
 st.title("Dashboard Avanzado de Productividad de Agentes")
 st.markdown("Análisis integral del rendimiento, carga de trabajo y eficiencia operativa del equipo de atención.")
 
-# --- Carga de Archivos en la Barra Lateral ---
-st.sidebar.header("Carga de Archivos")
+# Estado inicial y pestañas
+if "files_uploaded" not in st.session_state:
+    st.session_state["files_uploaded"] = False
+if "df_users" not in st.session_state:
+    st.session_state["df_users"] = None
+if "df_sessions" not in st.session_state:
+    st.session_state["df_sessions"] = None
 
-# MEJORA 1: Instrucciones y enlaces para la descarga de archivos.
-st.sidebar.subheader("1. Archivo de Conversaciones")
-st.sidebar.markdown(
-    """
-    Descarga desde: [Dashboard de Usuarios](https://go.botmaker.com/#/dashboards/userAndSessions)
-    1. Filtra el periodo de interés.
-    2. Presiona en **'Descargar usuarios'**.
-    3. Importa el archivo **'users...'**
-    """,
-    unsafe_allow_html=True
-)
-uploaded_users = st.sidebar.file_uploader(
-    "Sube el archivo de usuarios (users...)",
-    type=['tsv', 'csv'],
-    key="users_uploader",
-    label_visibility="collapsed"
-)
+if st.session_state["files_uploaded"]:
+    tab_dashboard, tab_upload = st.tabs(["Dashboard", "Carga de archivos"])
+else:
+    tab_upload, tab_dashboard = st.tabs(["Carga de archivos", "Dashboard"])
 
-st.sidebar.divider()
+with tab_upload:
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader("1. Archivo de Conversaciones")
+        st.markdown(
+            """
+            Descarga desde: [Dashboard de Usuarios](https://go.botmaker.com/#/dashboards/userAndSessions)
+            1. Filtra el periodo de interés.
+            2. Presiona en **'Descargar usuarios'**.
+            3. Importa el archivo **'users...'**
+            """,
+            unsafe_allow_html=True,
+        )
+        uploaded_users = st.file_uploader(
+            "Sube el archivo de usuarios (users...)",
+            type=["tsv", "csv"],
+            key="users_uploader",
+            label_visibility="collapsed",
+        )
+    with col2:
+        st.subheader("2. Archivo de Sesiones de Agentes")
+        st.markdown(
+            """
+            Descarga desde: [Dashboard Tiempo Real](https://go.botmaker.com/#/dashboards/oprealtime)
+            1. Filtra el periodo de interés.
+            2. Presiona en **'Descargar por conversación'**.
+            3. Importa el archivo **'operatorsSessions...'**
+            """,
+            unsafe_allow_html=True,
+        )
+        uploaded_operators_sessions = st.file_uploader(
+            "Sube el archivo de sesiones (operatorsSessions...)",
+            type=["tsv", "csv"],
+            key="sessions_uploader",
+            label_visibility="collapsed",
+        )
 
-st.sidebar.subheader("2. Archivo de Sesiones de Agentes")
-st.sidebar.markdown(
-    """
-    Descarga desde: [Dashboard Tiempo Real](https://go.botmaker.com/#/dashboards/oprealtime)
-    1. Filtra el periodo de interés.
-    2. Presiona en **'Descargar por conversación'**.
-    3. Importa el archivo **'operatorsSessions...'**
-    """,
-    unsafe_allow_html=True
-)
-uploaded_operators_sessions = st.sidebar.file_uploader(
-    "Sube el archivo de sesiones (operatorsSessions...)",
-    type=['tsv', 'csv'],
-    key="sessions_uploader",
-    label_visibility="collapsed"
-)
+    st.divider()
+
+    video_path = os.path.join("media", "instructivo_importacion.mp4")
+    if os.path.exists(video_path):
+        st.video(video_path)
+    else:
+        st.warning("No se encontró el video instructivo.")
+
+    if uploaded_users and uploaded_operators_sessions and not st.session_state["files_uploaded"]:
+        df_users_raw = load_users_data(uploaded_users)
+        df_sessions_raw = load_sessions_data(uploaded_operators_sessions)
+        if df_users_raw is not None and df_sessions_raw is not None and validate_dataframes(df_sessions_raw, df_users_raw):
+            st.session_state["df_users"] = df_users_raw
+            st.session_state["df_sessions"] = df_sessions_raw
+            st.session_state["files_uploaded"] = True
+            st.success("✅ ¡Archivos cargados y validados! Redirigiendo al Dashboard...")
+            st.experimental_rerun()
 
 
 # --- Lógica Principal del Dashboard ---
-if uploaded_users and uploaded_operators_sessions:
+with tab_dashboard:
+    if st.session_state["files_uploaded"]:
+        df_users_raw = st.session_state["df_users"]
+        df_sessions_raw = st.session_state["df_sessions"]
+
+        if df_users_raw is not None and df_sessions_raw is not None and validate_dataframes(df_sessions_raw, df_users_raw):
+            df_procesado = clean_and_prepare_data(df_sessions_raw.copy(), df_users_raw.copy())
+
+            # --- Header con Filtros ---
+            st.header("🔍 Filtros de Análisis")
+            with st.expander("Selecciona los filtros para acotar el análisis", expanded=True):
+                col1, col2, col3 = st.columns(3)
+
+                # Filtro de Agentes
+                lista_agentes = sorted(df_procesado['Nombre Agente'].unique())
+                agentes_seleccionados = col1.multiselect(
+                    "Agentes", options=lista_agentes, default=lista_agentes,
+                    help="Selecciona los agentes a incluir en el análisis."
+                )
+
+                # Filtro de Colas de Atención
+                lista_colas = sorted(df_procesado['Cola'].unique())
+                colas_seleccionadas = col2.multiselect(
+                    "Colas de Atención", options=lista_colas, default=lista_colas,
+                    help="Filtra por las colas de atención. Ayuda a comparar el rendimiento en diferentes áreas (ej. Ventas vs. Soporte)."
+                )
+
+                # Filtro de Fechas
+                min_fecha = df_procesado['Fecha'].min()
+                max_fecha = df_procesado['Fecha'].max()
+                fecha_seleccionada = col3.date_input(
+                    "Rango de Fechas", value=(min_fecha, max_fecha),
+                    min_value=min_fecha, max_value=max_fecha,
+                    help="Selecciona el rango de fechas para el análisis."
+                )
+
+            # --- Aplicar Filtros ---
+            if len(fecha_seleccionada) != 2:
+                st.warning("Por favor, selecciona un rango de fechas válido (inicio y fin).")
+                st.stop()
+
+            df_filtrado = df_procesado[
+                (df_procesado['Nombre Agente'].isin(agentes_seleccionados)) &
+                (df_procesado['Cola'].isin(colas_seleccionadas)) &
+                (df_procesado['Fecha'] >= fecha_seleccionada[0]) &
+                (df_procesado['Fecha'] <= fecha_seleccionada[1])
+            ]
+
+            if df_filtrado.empty:
+                st.error("No se encontraron datos para los filtros seleccionados. Por favor, ajusta tu selección.")
+            else:
+                # --- KPIs Principales ---
+                st.header("📊 Métricas Clave del Periodo")
+                st.markdown("Un vistazo rápido a los indicadores más importantes de la operación según tu selección.")
+
+                # Cálculos de KPIs
+                total_conversations = df_filtrado['Conversaciones cerradas'].sum()
+                total_abandons = df_filtrado['Abandonada por usuario'].sum()
+                abandon_rate = (total_abandons / total_conversations * 100) if total_conversations > 0 else 0
+                total_transfers = df_filtrado['Transferencias realizadas'].sum()
+                avg_handle_time_seconds = df_filtrado['Conversación con agente'].mean()
+
+                # --- NUEVO CÁLCULO DE KPI ---
+                avg_response_time_seconds = df_filtrado['Tiempo medio de respuesta'].mean()
+                avg_response_time_hours = (avg_response_time_seconds / 3600) if pd.notna(avg_response_time_seconds) else 0
+
+                # Se cambia a 5 columnas para el nuevo KPI
+                kpi_cols = st.columns(4)
+                kpi_cols[0].metric(
+                    label="Total Conversaciones Atendidas",
+                    value=f"{int(total_conversations):,}",
+                    help="Total de conversaciones atendidas en el periodo.\n\n**Fórmula:** Σ (<operatorSessionsDebug>.Conversaciones cerradas).",
+                )
+                kpi_cols[1].metric(
+                    label="Tasa de Abandono (Usuario)",
+                    value=f"{abandon_rate:.1f}%",
+                    help="Porcentaje de conversaciones abandonadas por el usuario.\n\n**Fórmula:** (Σ <operatorSessionsDebug>.Abandonada por usuario / Σ <operatorSessionsDebug>.Conversaciones cerradas) × 100.",
+                )
+                kpi_cols[2].metric(
+                    label="Tiempo Promedio Conversación (AHT)",
+                    value=f"{avg_handle_time_seconds / 60:.1f} min" if pd.notna(avg_handle_time_seconds) else "N/A",
+                    help="Desde que el usuario entra en una cola hasta el cierre de la conversación.\n\n**Fórmula:** Promedio(<operatorSessionsDebug>.Conversación con agente) / 60.",
+                )
+                kpi_cols[3].metric(
+                    label="Tiempo Medio de Respuesta",
+                    value=f"{avg_response_time_hours:.2f} hrs" if avg_response_time_hours > 0 else "N/A",
+                    help="Tiempo promedio que demora un asesor en responderle al cliente cada mensaje.\n\n**Fórmula:** Promedio(<operatorSessionsDebug>.Tiempo medio de respuesta) / 3600.",
+                )
+
+                st.divider()
+
+                # --- Análisis Temporal ---
+                st.header("🗓️ Evolución Temporal")
+                daily_volume = (
+                    df_filtrado.groupby(['Fecha', 'Nombre Agente'])
+                    .agg(total_conversations=('Conversaciones cerradas', 'sum'))
+                    .reset_index()
+                )
+
+                st.subheader(
+                    "Volumen de Conversaciones por Día",
+                    help="Cantidad de conversaciones cerradas por día según la fecha de inicio de sesión del agente.\n\n**Fórmula:** Σ (<operatorSessionsDebug>.Conversaciones cerradas) agrupado por <operatorSessionsDebug>.Fecha/tiempo Inicio Sesión.",
+                )
+
+                view_mode = st.radio(
+                    "Visualización",
+                    ["Gráfico", "Tabla"],
+                    horizontal=True,
+                    key="daily_view_mode",
+                )
+
+                if view_mode == "Tabla":
+                    pivot_daily = (
+                        daily_volume.pivot(
+                            index='Fecha',
+                            columns='Nombre Agente',
+                            values='total_conversations'
+                        )
+                        .fillna(0)
+                        .astype(int)
+                    )
+                    st.dataframe(pivot_daily, use_container_width=True)
+                else:
+                    fig_daily = px.line(
+                        daily_volume,
+                        x='Fecha',
+                        y='total_conversations',
+                        color='Nombre Agente',
+                        title='Volumen de Conversaciones por Día',
+                        labels={'Fecha': 'Día', 'total_conversations': 'Conversaciones'},
+                    )
+                    st.plotly_chart(fig_daily, use_container_width=True, theme="streamlit")
+
+                st.divider()
+
+                # --- Rendimiento por Agente ---
+                st.header("👨‍💻 Rendimiento por Agente")
+                agent_performance = (
+                    df_filtrado.groupby('Nombre Agente')
+                    .agg(
+                        total_conversations=('Conversaciones cerradas', 'sum'),
+                        total_messages=('Mensajes Agente', 'sum'),
+                        avg_handle_time=('Conversación con agente', 'mean'),
+                        avg_response_time=('Tiempo medio de respuesta', 'mean')
+                    )
+                    .reset_index()
+                )
+
+                with st.container():
+                    chart_cols = st.columns(3)
+                    with chart_cols[0]:
+                        st.subheader(
+                            "Volumen de Conversaciones",
+                            help="Cantidad total de conversaciones manejadas por cada agente.\n\n**Fórmula:** Σ (<operatorSessionsDebug>.Conversaciones cerradas) por <operatorSessionsDebug>.Nombre Agente.",
+                        )
+                        fig_conv = px.bar(
+                            agent_performance,
+                            x='Nombre Agente',
+                            y='total_conversations',
+                            title="Volumen de Conversaciones",
+                            labels={'Nombre Agente': 'Agente', 'total_conversations': 'Nº de Conversaciones'},
+                            text='total_conversations',
+                            color='Nombre Agente'
+                        )
+                        fig_conv.update_layout(showlegend=False)
+                        st.plotly_chart(fig_conv, use_container_width=True, theme="streamlit")
+                        st.info(
+                            " Mide cuántas conversaciones gestionó cada agente en el periodo. Un mayor volumen indica una mayor carga de trabajo."
+                        )
+
+                    with chart_cols[1]:
+                        st.subheader(
+                            "Promedio de Conversación (Minutos)",
+                            help="Tiempo promedio que cada agente dedica a una conversación.\n\n**Fórmula:** Promedio(<operatorSessionsDebug>.Conversación con agente) / 60 por <operatorSessionsDebug>.Nombre Agente.",
+                        )
+                        fig_aht = px.bar(
+                            agent_performance,
+                            x='Nombre Agente',
+                            y=agent_performance['avg_handle_time'] / 60,
+                            title="Promedio de Conversación (Minutos)",
+                            labels={'Nombre Agente': 'Agente', 'y': 'Tiempo (min)'},
+                            text=(agent_performance['avg_handle_time'] / 60).round(2),
+                            color='Nombre Agente'
+                        )
+                        fig_aht.update_layout(showlegend=False)
+                        st.plotly_chart(fig_aht, use_container_width=True, theme="streamlit")
+                        st.info(
+                            " Representa el tiempo promedio que cada agente demora en resolver una conversación. Valores más bajos generalmente indican mayor eficiencia."
+                        )
+
+                    with chart_cols[2]:
+                        st.subheader(
+                            "Tiempo Medio de Respuesta (Horas)",
+                            help="Promedio de tiempo que tarda un agente en responder al cliente.\n\n**Fórmula:** Promedio(<operatorSessionsDebug>.Tiempo medio de respuesta) / 3600 por <operatorSessionsDebug>.Nombre Agente.",
+                        )
+                        fig_response = px.bar(
+                            agent_performance,
+                            x='Nombre Agente',
+                            y=agent_performance['avg_response_time'] / 3600,
+                            title="Tiempo Medio de Respuesta (Horas)",
+                            labels={'Nombre Agente': 'Agente', 'y': 'Tiempo (hrs)'},
+                            text=(agent_performance['avg_response_time'] / 3600).round(2),
+                            color='Nombre Agente'
+                        )
+                        if pd.notna(avg_response_time_hours) and avg_response_time_hours > 0:
+                            fig_response.add_hline(
+                                y=avg_response_time_hours,
+                                line=dict(color="gray", width=2, dash="dot"),
+                                annotation_text=f"Promedio Equipo: {avg_response_time_hours:.2f} hrs",
+                                annotation_position="bottom right",
+                                annotation_font_color="gray",
+                            )
+                        fig_response.update_layout(showlegend=False)
+                        st.plotly_chart(fig_response, use_container_width=True, theme="streamlit")
+                        st.info(" Refleja el tiempo promedio que demora cada agente en enviar su primera respuesta. Valores más bajos indican una atención inicial más rápida.")
+
+                st.divider()
+
+                # --- Matriz de Eficiencia vs. Carga de Trabajo ---
+                st.header("⏺️ Matriz de Eficiencia vs. Carga de Trabajo")
+                st.subheader(
+                    "Carga de Trabajo vs. Tiempo de Manejo",
+                    help="Relaciona la cantidad de conversaciones atendidas con el tiempo promedio de manejo.\n\n**Fórmula:** Eje X: Σ (<operatorSessionsDebug>.Conversaciones cerradas). Eje Y: Promedio(<operatorSessionsDebug>.Conversación con agente) / 60. Tamaño: Σ (<users>.Mensajes Agente).",
+                )
+                fig_scatter = px.scatter(
+                    agent_performance,
+                    x='total_conversations',
+                    y=agent_performance['avg_handle_time'] / 60,
+                    size='total_messages',
+                    color='Nombre Agente',
+                    hover_name='Nombre Agente',
+                    size_max=60,
+                    title='Carga de Trabajo vs. Tiempo de Manejo',
+                    labels={"total_conversations": "Número de Conversaciones Atendidas", "y": "Tiempo Promedio de Conversación (minutos)"},
+                )
+                fig_scatter.update_layout(showlegend=True, legend_title_text='Agentes')
+                st.plotly_chart(fig_scatter, use_container_width=True, theme="streamlit")
+                st.info(
+                    """
+                    **¿Cómo leer este gráfico?**
+                    - **Eje Horizontal (Más a la derecha):** Agentes que manejan más conversaciones (mayor carga de trabajo).
+                    - **Eje Vertical (Más arriba):** Agentes que dedican, en promedio, más tiempo a cada conversación.
+                    - **Tamaño de la burbuja:** Representa la cantidad total de **mensajes enviados** por el agente, un indicador del esfuerzo de comunicación.
+                    """
+                )
+
+                st.divider()
+
+                # --- Análisis de Tipificaciones ---
+                st.header("🏷️ Resultados de las Conversaciones (Tipificaciones)")
+                tipificaciones = df_filtrado['Tipificación_user'].dropna().value_counts().reset_index()
+                tipificaciones.columns = ['Tipificación', 'Cantidad']
+
+                if not tipificaciones.empty:
+                    col1, col2 = st.columns(2)
+                    with col1:
+                        st.subheader(
+                            "Distribución General de Tipificaciones",
+                            help="Conteo total de resultados de tipificación registrados.\n\n**Fórmula:** Conteo(<users>.Tipificación).",
+                        )
+                        fig_tipif_bar = px.bar(
+                            tipificaciones.sort_values('Cantidad', ascending=True),
+                            x='Cantidad', y='Tipificación', orientation='h',
+                            title='Conteo Total por Tipificación', text='Cantidad'
+                        )
+                        fig_tipif_bar.update_layout(showlegend=False, yaxis_title=None)
+                        st.plotly_chart(fig_tipif_bar, use_container_width=True, theme="streamlit")
+                        st.info(
+                            " Resumen de las tipificaciones de las conversaciones realizadas por los agentes. Es recomendable realizar las tipificaciones al finalizar cada conversación para una mejor categorización y análisis.\n\n"
+                        )
+
+                    with col2:
+                        st.subheader(
+                            "Tipificaciones por Agente",
+                            help="Comparativa de resultados de tipificación para cada agente.\n\n**Fórmula:** Conteo(<users>.Tipificación) por <operatorSessionsDebug>.Nombre Agente.",
+                        )
+                        tipif_by_agent = df_filtrado.groupby(['Nombre Agente', 'Tipificación_user']).size().reset_index(name='Cantidad')
+                        fig_stacked_bar = px.bar(
+                            tipif_by_agent, x='Nombre Agente', y='Cantidad',
+                            color='Tipificación_user', title='Composición de Resultados por Agente',
+                            labels={'Nombre Agente': 'Agente', 'Cantidad': 'Nº de Conversaciones', 'Tipificación_user': 'Tipificación'}
+                        )
+                        st.plotly_chart(fig_stacked_bar, use_container_width=True, theme="streamlit")
+                        st.info(
+                            " Compara cómo se distribuyen los resultados de las conversaciones entre los diferentes agentes."
+                        )
+                else:
+                    st.info("No hay datos de tipificación disponibles para el periodo y filtros seleccionados.")
+        else:
+            st.error("Los archivos cargados parecen ser incorrectos. Por favor, vuelve a la pestaña 'Carga de archivos'.")
+    else:
+        st.info("👋 Sube los archivos de 'Usuarios' y 'Sesiones de Agentes' en la pestaña 'Carga de archivos' para comenzar el análisis.")
     df_users_raw = load_users_data(uploaded_users)
     df_sessions_raw = load_sessions_data(uploaded_operators_sessions)
 
@@ -511,14 +830,3 @@ if uploaded_users and uploaded_operators_sessions:
                         )
                 else:
                     st.info("No hay datos de tipificación disponibles para el periodo y filtros seleccionados.")
-
-else:
-    # MEJORA 2: Mostrar video instructivo si no hay archivos cargados.
-    st.info("👋 ¡Bienvenido! Sube los archivos de 'Usuarios' y 'Sesiones de Agentes' para comenzar el análisis.")
-
-    # Reproduce un video instructivo sobre cómo importar los datos
-    video_path = os.path.join("media", "instructivo_importacion.mp4")
-    if os.path.exists(video_path):
-        st.video(video_path)
-    else:
-        st.warning("No se encontró el video instructivo.")


### PR DESCRIPTION
## Summary
- move file upload flow from sidebar to a dedicated tab-based interface
- store upload results in session state and redirect to dashboard when both files are validated

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f92c8efec8333957a27f27b5ddba2